### PR TITLE
Fixes saved state of brewery card not persisting between nav changes

### DIFF
--- a/src/components/BreweryCard/index.jsx
+++ b/src/components/BreweryCard/index.jsx
@@ -5,7 +5,7 @@ import { ButtonControl } from '../../components';
 
 const BreweryCard = ({ data }) => {
 
-    const saved = useSelector(state => state.breweries.saved.includes(data))
+    const saved = useSelector(state => state.breweries.saved.some((card => card.id === data.id)))
     const dispatch = useDispatch();
 
     const handleSave = () => {


### PR DESCRIPTION
Currently, BreweryCard component does not persist the saved state of a brewery when you navigate away from the Breweries page and back again. Because of this, a user can select to add the same brewery more than once which causes duplicates on the Saved page.

This bug is occurring because `include` is being used to check whether an object exists inside an array of objects. It turns out you can't do this for reasons explained in this [StackOverflow article](https://stackoverflow.com/questions/51603456/array-includes-to-find-object-in-array). The recommendation is to use `some` instead. I've updated the code accordingly.