### PR TITLE
package-lock file name change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "brewery_app",
+  "name": "brewery-app",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
When I run `npm install` on the repo, package-lock.json changes the name from using an underscore to a dash. Presumably because of the repo name which includes a dash.

Doing a PR on this so that others won't end up with a modified package-lock file immediately after install.